### PR TITLE
Include futures in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-matplotlib==1.5.1
-requests==2.11.1
+matplotlib>=1.5.1
+requests>=2.11.1
+futures>=3.0.5


### PR DESCRIPTION
It would be nice to mention somewhere that this works only with python2.   I actually did not use pip, but used the following in anaconda, which worked fine:
```
conda config --add channels conda-forge --force
conda create -n realtime python=2.7 matplotlib requests futures
source activate realtime
```